### PR TITLE
Fix scala import

### DIFF
--- a/rules/scala/private/import.bzl
+++ b/rules/scala/private/import.bzl
@@ -16,7 +16,16 @@ def scala_import_implementation(ctx):
     )
 
     if ctx.files.jars:
-        output_jar = ctx.files.jars[0]
+        _jar = []
+        _src_jar = []
+        for jar in ctx.files.jars:
+            if jar.basename.endswith("sources.jar") or jar.basename.endswith("src.jar"):
+                _src_jar.append(jar)
+            else:
+                _jar.append(jar)
+        _src_jar += ctx.files.srcjar
+
+        output_jar = _jar[0]
 
         # TODO: maybe eventually we should use this. Right now it produces
         # a warning:
@@ -41,7 +50,7 @@ def scala_import_implementation(ctx):
         source_jar = java_common.pack_sources(
             ctx.actions,
             output_jar = output_jar,
-            source_jars = ctx.files.srcjar or ctx.files.jars,
+            source_jars = _src_jar,
             host_javabase = ctx.attr._host_javabase,
             java_toolchain = ctx.attr._java_toolchain,
         )

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 http_archive(
@@ -177,4 +177,18 @@ jvm_maven_import_external(
 bind(
     name = "default_scala",
     actual = "//scala:zinc_typelevel_2_12_1",
+)
+
+http_file(
+    name = "shapeless_jar",
+    downloaded_file_path = "shapeless.jar",
+    sha256 = "75926d9dd4688710ca16d852b58746dcfc013a2a1a58d1e817a27f95b2d42303",
+    urls = ["https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"],
+)
+
+http_file(
+    name = "shapeless_srcjar",
+    downloaded_file_path = "shapeless-sources.jar",
+    sha256 = "6c00f4454ee1250fb2385e01e02d5751bdf6594e847befab5dbe417c95dbd2b9",
+    urls = ["https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"],
 )

--- a/tests/scala/scalaimport/BUILD
+++ b/tests/scala/scalaimport/BUILD
@@ -1,0 +1,21 @@
+load("@rules_scala_annex//rules:scala.bzl", "scala_import", "scala_library")
+
+scala_import(
+    name = "shapeless",
+    jars = [
+        "@shapeless_jar//file",
+        "@shapeless_srcjar//file",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+scala_library(
+    name = "scalaimport",
+    srcs = ["scalaimport.scala"],
+    deps = [
+        ":shapeless",
+        "@org_scala_lang_modules_scala_xml_2_12//jar",
+    ],
+)

--- a/tests/scala/scalaimport/scalaimport.scala
+++ b/tests/scala/scalaimport/scalaimport.scala
@@ -1,0 +1,13 @@
+// This is a test for the correctness of scala_import. It intends to import
+// 3rdparty dependencies.
+
+import shapeless._
+
+object Test {
+
+    type T = Int :: HNil
+
+    def main(args: Array[String]): Unit = {
+        val xml = <things><thing1></thing1><thing2></thing2></things>
+    }
+}

--- a/tests/scala/scalaimport/test
+++ b/tests/scala/scalaimport/test
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+. "$(dirname "$0")"/../../common.sh
+
+bazel build :scalaimport


### PR DESCRIPTION
This is a quick fix to support upstream bazel_deps. The future work is to support both lucidsoftware bazel_deps and upstream bazel_deps gracefully. We should also improve the scala_import test.