### PR TITLE
Support utf-8 formatting

### DIFF
--- a/rules/scalafmt/private/test.bzl
+++ b/rules/scalafmt/private/test.bzl
@@ -41,7 +41,7 @@ def build_format(ctx):
             args.set_param_file_format("multiline")
             args.use_param_file("@%s", use_always = True)
             ctx.actions.run(
-                arguments = [args],  #["--jvm_flag=-Dfile.encoding=" + toolchain.encoding, args],
+                arguments = ["--jvm_flag=-Dfile.encoding=UTF-8", args],
                 executable = ctx.executable._fmt,
                 outputs = [file],
                 input_manifests = runner_manifests,

--- a/tests/format/scalafmt/BUILD
+++ b/tests/format/scalafmt/BUILD
@@ -74,3 +74,15 @@ scala_test(
     srcs = ["unformatted.tmp.scala"],
     format = True,
 )
+
+### utf8 encoding test ###
+scala_format_test(
+    name = "utf8-encoding-test-default",
+    srcs = ["utf8-unformatted.tmp.scala"],
+)
+
+scala_binary(
+    name = "utf8-encoding-test-non-default",
+    srcs = ["utf8-unformatted.tmp.scala"],
+    format = True,
+)

--- a/tests/format/scalafmt/test
+++ b/tests/format/scalafmt/test
@@ -44,3 +44,15 @@ cp unformatted.template.scala unformatted.tmp.scala
 bazel run :unformatted-test-copy.format
 bazel run :unformatted-test-copy.format-test
 rm unformatted.tmp.scala
+
+# utf-8 encoding formatting test
+## scala_format_test
+cp utf8-unformatted.template.scala utf8-unformatted.tmp.scala
+bazel run :utf8-encoding-test-default
+diff utf8-unformatted.tmp.scala utf8-formatted.scala
+rm utf8-unformatted.tmp.scala
+## scala_binary (non-default)
+cp utf8-unformatted.template.scala utf8-unformatted.tmp.scala
+bazel run :utf8-encoding-test-non-default.format
+diff utf8-unformatted.tmp.scala utf8-formatted.scala
+rm utf8-unformatted.tmp.scala

--- a/tests/format/scalafmt/utf8-formatted.scala
+++ b/tests/format/scalafmt/utf8-formatted.scala
@@ -1,0 +1,12 @@
+object HelloWorld {
+  def main(args: Array[String]) {
+    println("Be careful with this test")
+    println("小心這個測試")
+    println("このテストに注意してください")
+    println("이 시험에 조심하십시오")
+    println("كن حذرا مع هذا الاختبار")
+    println("Hãy cẩn thận với bài kiểm tra này")
+    println("Будьте осторожны с этим тестом")
+    println("😁✊🚀🍟💯")
+  }
+}

--- a/tests/format/scalafmt/utf8-unformatted.template.scala
+++ b/tests/format/scalafmt/utf8-unformatted.template.scala
@@ -1,0 +1,12 @@
+object HelloWorld {
+  def main(args: Array[String]) {
+    println("Be careful with this test")
+    println ("小心這個測試")
+    println  ("このテストに注意してください")
+    println   ("이 시험에 조심하십시오")
+    println    ("كن حذرا مع هذا الاختبار")
+    println     ("Hãy cẩn thận với bài kiểm tra này")
+    println      ("Будьте осторожны с этим тестом")
+    println       ("😁✊🚀🍟💯")
+  }
+}


### PR DESCRIPTION
Not sure if we necessarily need the toolchains to achieve it, but putting `--jvm_flag` back is sufficient as far as I can tell.