### PR TITLE
Fix for issue 178

### DIFF
--- a/rules/scala/private/doc.bzl
+++ b/rules/scala/private/doc.bzl
@@ -24,7 +24,7 @@ def scaladoc_implementation(ctx):
     html = ctx.actions.declare_directory("html")
     tmp = ctx.actions.declare_directory("tmp")
 
-    classpath = depset(transitive = [dep[JavaInfo].transitive_compile_time_deps for dep in ctx.attr.deps])
+    classpath = depset(transitive = [dep[JavaInfo].transitive_deps for dep in ctx.attr.deps])
     compiler_classpath = depset(
         transitive =
             [scompiler_classpath.transitive_runtime_deps] +

--- a/tests/mockutil/BUILD.bazel
+++ b/tests/mockutil/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_scala_annex//rules:scala.bzl", "scala_library")
+
+scala_library(
+    name = "mocklib",
+    srcs = ["MockLib.scala"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/mockutil/MockLib.scala
+++ b/tests/mockutil/MockLib.scala
@@ -1,0 +1,11 @@
+package mockutil
+
+/** Mocklib
+ *
+ * Utility functions
+ */
+object MockLib {
+  def add(i1: Int, i2: Int): Int = {
+    i1 + i2
+  }
+}

--- a/tests/scaladoc/A.scala
+++ b/tests/scaladoc/A.scala
@@ -1,6 +1,9 @@
+import mockutil.MockLib
+
 /**
  * A Scaladoc
  */
 object A {
     def a = B
+    def addOne(i: Int) = MockLib.add(i, 1)
 }

--- a/tests/scaladoc/BUILD
+++ b/tests/scaladoc/BUILD
@@ -10,4 +10,7 @@ scaladoc(
         "@annex_test//:org_scala_lang_modules_scala_xml_2_12",
     ],
     scala = "//scala:2_12",
+    deps = [
+        "//mockutil:mocklib",
+    ],
 )


### PR DESCRIPTION
I'm fairly certain we meant to do `dep[JavaInfo].transitive_deps` and not `dep[JavaInfo].transitive_compile_time_deps`: https://docs.bazel.build/versions/master/skylark/lib/JavaInfo.html#transitive_deps

Resolves #178 