### PR TITLE
Update the _java attribute to use current_java_runtime and get rid of warnings

### DIFF
--- a/rules/private/phases/phase_binary_launcher.bzl
+++ b/rules/private/phases/phase_binary_launcher.bzl
@@ -34,9 +34,8 @@ def phase_binary_launcher(ctx, g):
         runfiles = ctx.runfiles(
             files = inputs + files,
             transitive_files = depset(
-                direct = [ctx.executable._java],
                 order = "default",
-                transitive = [g.javainfo.java_info.transitive_runtime_deps],
+                transitive = [ctx.attr._jdk[java_common.JavaRuntimeInfo].files, g.javainfo.java_info.transitive_runtime_deps],
             ),
             collect_default = True,
         ),

--- a/rules/private/phases/phase_bootstrap_compile.bzl
+++ b/rules/private/phases/phase_bootstrap_compile.bzl
@@ -16,8 +16,8 @@ def phase_bootstrap_compile(ctx, g):
         fail("source jars supported for bootstrap_scala rules")
 
     inputs = depset(
-        [ctx.executable._java] + ctx.files.srcs,
-        transitive = [g.classpaths.compile, g.classpaths.compiler],
+        ctx.files.srcs,
+        transitive = [ctx.attr._jdk[java_common.JavaRuntimeInfo].files, g.classpaths.compile, g.classpaths.compiler],
     )
 
     compiler_classpath = ":".join([f.path for f in g.classpaths.compiler.to_list()])
@@ -43,7 +43,7 @@ def phase_bootstrap_compile(ctx, g):
             |
             |{jar_creator} {output_jar} tmp/classes 2> /dev/null
             |""".format(
-                java = ctx.executable._java.path,
+                java = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path,
                 jar_creator = ctx.executable._jar_creator.path,
                 compiler_classpath = compiler_classpath,
                 compile_classpath = compile_classpath,

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -70,9 +70,9 @@ _compile_private_attributes = {
 
     # TODO: push java and jar_creator into a provider for the
     # bootstrap compile phase
-    "_java": attr.label(
-        default = Label("@bazel_tools//tools/jdk:java"),
-        executable = True,
+    "_jdk": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        providers = [java_common.JavaRuntimeInfo],
         cfg = "host",
     ),
     "_jar_creator": attr.label(
@@ -167,9 +167,9 @@ _runtime_attributes = {
 }
 
 _runtime_private_attributes = {
-    "_java": attr.label(
-        default = Label("@bazel_tools//tools/jdk:java"),
-        executable = True,
+    "_jdk": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        providers = [java_common.JavaRuntimeInfo],
         cfg = "host",
     ),
     "_java_stub_template": attr.label(

--- a/rules/scala/private/repl.bzl
+++ b/rules/scala/private/repl.bzl
@@ -50,7 +50,7 @@ def scala_repl_implementation(ctx):
             runfiles = ctx.runfiles(
                 collect_default = True,
                 collect_data = True,
-                files = [ctx.executable._java],
+                files = [ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path],
                 transitive_files = files,
             ),
         ),


### PR DESCRIPTION
The current code with more recent versions of Bazel causes a warning about using the deprecated target '@local_jdk//:java' and to use use @bazel_tools//tools/jdk:current_java_runtime instead (see https://github.com/bazelbuild/bazel/issues/5594).