### PR TITLE
Update protobuf to remove warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,10 +25,13 @@ git_repository(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "2c8f8614fb1be709d68abaab6b4791682aa7db2048012dd4642d3a50b4f67cb3",
-    strip_prefix = "protobuf-0038ff49af882463c2af9049356eed7df45c3e8e",
-    urls = ["https://github.com/google/protobuf/archive/0038ff49af882463c2af9049356eed7df45c3e8e.zip"],
+    sha256 = "0963c6ae20340ce41f225a99cacbcba8422cebe4f82937f3d9fa3f5dd7ae7342",
+    strip_prefix = "protobuf-9f604ac5043e9ab127b99420e957504f2149adbe",
+    urls = ["https://github.com/google/protobuf/archive/9f604ac5043e9ab127b99420e957504f2149adbe.zip"],
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 
 http_archive(
     name = "rules_jvm_external",

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -10,10 +10,13 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "2c8f8614fb1be709d68abaab6b4791682aa7db2048012dd4642d3a50b4f67cb3",
-    strip_prefix = "protobuf-0038ff49af882463c2af9049356eed7df45c3e8e",
-    urls = ["https://github.com/google/protobuf/archive/0038ff49af882463c2af9049356eed7df45c3e8e.zip"],
+    sha256 = "0963c6ae20340ce41f225a99cacbcba8422cebe4f82937f3d9fa3f5dd7ae7342",
+    strip_prefix = "protobuf-9f604ac5043e9ab127b99420e957504f2149adbe",
+    urls = ["https://github.com/google/protobuf/archive/9f604ac5043e9ab127b99420e957504f2149adbe.zip"],
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 
 local_repository(
     name = "rules_scala_annex",


### PR DESCRIPTION
The older version of protobuf is causing a warning like:
An illegal reflective access operation has occurred