### PR TITLE
Allow passing ScalaPB generator options to the toolchain

### DIFF
--- a/docs/stardoc/scala_proto.md
+++ b/docs/stardoc/scala_proto.md
@@ -49,7 +49,7 @@ See example use in [/tests/proto/BUILD](/tests/proto/BUILD)
 ## scala_proto_toolchain
 
 <pre>
-scala_proto_toolchain(<a href="#scala_proto_toolchain-name">name</a>, <a href="#scala_proto_toolchain-compiler">compiler</a>, <a href="#scala_proto_toolchain-compiler_supports_workers">compiler_supports_workers</a>)
+scala_proto_toolchain(<a href="#scala_proto_toolchain-name">name</a>, <a href="#scala_proto_toolchain-compiler">compiler</a>, <a href="#scala_proto_toolchain-compiler_supports_workers">compiler_supports_workers</a>, <a href="#scala_proto_toolchain-generator_params">generator_params</a>)
 </pre>
 
 
@@ -65,6 +65,7 @@ scala_proto_toolchain(
     name = "scalapb_toolchain_example",
     compiler = ":worker",
     compiler_supports_workers = True,
+    generator_params = "grpc,java_conversions",
     visibility = ["//visibility:public"],
 )
 
@@ -115,6 +116,15 @@ toolchain(
       <td><code>compiler_supports_workers</code></td>
       <td>
         Boolean; optional
+      </td>
+    </tr>
+    <tr id="scala_proto_toolchain-generator_params">
+      <td><code>generator_params</code></td>
+      <td>
+        String; optional
+        <p>
+          Generator params to pass to the scala PB compiler (ie java_conversions, flat_package, grpc)
+        </p>
       </td>
     </tr>
   </tbody>

--- a/rules/scala_proto.bzl
+++ b/rules/scala_proto.bzl
@@ -33,6 +33,7 @@ def _scala_proto_toolchain_implementation(ctx):
     return [platform_common.ToolchainInfo(
         compiler = ctx.attr.compiler,
         compiler_supports_workers = ctx.attr.compiler_supports_workers,
+        generator_params = ctx.attr.generator_params,
     )]
 
 scala_proto_toolchain = rule(
@@ -44,6 +45,10 @@ scala_proto_toolchain = rule(
             cfg = "host",
         ),
         "compiler_supports_workers": attr.bool(default = False),
+        "generator_params": attr.string(
+            doc = "Generator params to pass to the scala PB compiler (ie java_conversions, flat_package, grpc)",
+            default = "",
+        ),
     },
     doc = """
 Specifies a toolchain of the `@rules_scala_annex//rules/scala_proto:compiler_toolchain_type` toolchain type.
@@ -58,6 +63,7 @@ scala_proto_toolchain(
     name = "scalapb_toolchain_example",
     compiler = ":worker",
     compiler_supports_workers = True,
+    generator_params = "grpc,java_conversions",
     visibility = ["//visibility:public"],
 )
 

--- a/rules/scala_proto/private/core.bzl
+++ b/rules/scala_proto/private/core.bzl
@@ -32,6 +32,8 @@ def scala_proto_library_implementation(ctx):
 
     args = ctx.actions.args()
     args.add("--output_dir", gendir.path)
+    if compiler.generator_params:
+        args.add("--generator_params", compiler.generator_params)
     args.add_all("--", transitive_sources)
     args.set_param_file_format("multiline")
     args.use_param_file("@%s", use_always = True)


### PR DESCRIPTION
This allows the scala_proto_toolchain rule to configure the ScalaPB
generator options. Some options (grpc) cannot be configured on a per-file
basis, so this mechanism is necessary to use them.