### PR TITLE
Accept `global_scalacopts`

### DIFF
--- a/docs/stardoc/providers.md
+++ b/docs/stardoc/providers.md
@@ -5,7 +5,7 @@
 ## declare_scala_configuration
 
 <pre>
-declare_scala_configuration(<a href="#declare_scala_configuration-name">name</a>, <a href="#declare_scala_configuration-compiler_classpath">compiler_classpath</a>, <a href="#declare_scala_configuration-global_plugins">global_plugins</a>, <a href="#declare_scala_configuration-runtime_classpath">runtime_classpath</a>, <a href="#declare_scala_configuration-version">version</a>)
+declare_scala_configuration(<a href="#declare_scala_configuration-name">name</a>, <a href="#declare_scala_configuration-compiler_classpath">compiler_classpath</a>, <a href="#declare_scala_configuration-global_plugins">global_plugins</a>, <a href="#declare_scala_configuration-global_scalacopts">global_scalacopts</a>, <a href="#declare_scala_configuration-runtime_classpath">runtime_classpath</a>, <a href="#declare_scala_configuration-version">version</a>)
 </pre>
 
 Creates a `ScalaConfiguration`.
@@ -39,6 +39,15 @@ Creates a `ScalaConfiguration`.
         <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
         <p>
           Scalac plugins that will always be enabled.
+        </p>
+      </td>
+    </tr>
+    <tr id="declare_scala_configuration-global_scalacopts">
+      <td><code>global_scalacopts</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          Scalac options that will always be enabled.
         </p>
       </td>
     </tr>
@@ -316,7 +325,7 @@ Exported jars and their labels.
 ## ScalaConfiguration
 
 <pre>
-ScalaConfiguration(<a href="#ScalaConfiguration-version">version</a>, <a href="#ScalaConfiguration-compiler_classpath">compiler_classpath</a>, <a href="#ScalaConfiguration-runtime_classpath">runtime_classpath</a>, <a href="#ScalaConfiguration-global_plugins">global_plugins</a>)
+ScalaConfiguration(<a href="#ScalaConfiguration-version">version</a>, <a href="#ScalaConfiguration-compiler_classpath">compiler_classpath</a>, <a href="#ScalaConfiguration-runtime_classpath">runtime_classpath</a>, <a href="#ScalaConfiguration-global_plugins">global_plugins</a>, <a href="#ScalaConfiguration-global_scalacopts">global_scalacopts</a>)
 </pre>
 
 Scala compile-time and runtime configuration
@@ -351,6 +360,12 @@ Scala compile-time and runtime configuration
       <td><code>global_plugins</code></td>
       <td>
         <p>Globally enabled compiler plugins</p>
+      </td>
+    </tr>
+    <tr id="ScalaConfiguration-global_scalacopts">
+      <td><code>global_scalacopts</code></td>
+      <td>
+        <p>Globally enabled compiler options</p>
       </td>
     </tr>
   </tbody>

--- a/docs/stardoc/scala.md
+++ b/docs/stardoc/scala.md
@@ -5,7 +5,7 @@
 ## configure_bootstrap_scala
 
 <pre>
-configure_bootstrap_scala(<a href="#configure_bootstrap_scala-name">name</a>, <a href="#configure_bootstrap_scala-compiler_classpath">compiler_classpath</a>, <a href="#configure_bootstrap_scala-global_plugins">global_plugins</a>, <a href="#configure_bootstrap_scala-runtime_classpath">runtime_classpath</a>, <a href="#configure_bootstrap_scala-version">version</a>)
+configure_bootstrap_scala(<a href="#configure_bootstrap_scala-name">name</a>, <a href="#configure_bootstrap_scala-compiler_classpath">compiler_classpath</a>, <a href="#configure_bootstrap_scala-global_plugins">global_plugins</a>, <a href="#configure_bootstrap_scala-global_scalacopts">global_scalacopts</a>, <a href="#configure_bootstrap_scala-runtime_classpath">runtime_classpath</a>, <a href="#configure_bootstrap_scala-version">version</a>)
 </pre>
 
 
@@ -42,6 +42,15 @@ configure_bootstrap_scala(<a href="#configure_bootstrap_scala-name">name</a>, <a
         </p>
       </td>
     </tr>
+    <tr id="configure_bootstrap_scala-global_scalacopts">
+      <td><code>global_scalacopts</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          Scalac options that will always be enabled.
+        </p>
+      </td>
+    </tr>
     <tr id="configure_bootstrap_scala-runtime_classpath">
       <td><code>runtime_classpath</code></td>
       <td>
@@ -63,7 +72,7 @@ configure_bootstrap_scala(<a href="#configure_bootstrap_scala-name">name</a>, <a
 ## configure_zinc_scala
 
 <pre>
-configure_zinc_scala(<a href="#configure_zinc_scala-name">name</a>, <a href="#configure_zinc_scala-compiler_bridge">compiler_bridge</a>, <a href="#configure_zinc_scala-compiler_classpath">compiler_classpath</a>, <a href="#configure_zinc_scala-deps_direct">deps_direct</a>, <a href="#configure_zinc_scala-deps_used">deps_used</a>, <a href="#configure_zinc_scala-global_plugins">global_plugins</a>, <a href="#configure_zinc_scala-runtime_classpath">runtime_classpath</a>, <a href="#configure_zinc_scala-version">version</a>)
+configure_zinc_scala(<a href="#configure_zinc_scala-name">name</a>, <a href="#configure_zinc_scala-compiler_bridge">compiler_bridge</a>, <a href="#configure_zinc_scala-compiler_classpath">compiler_classpath</a>, <a href="#configure_zinc_scala-deps_direct">deps_direct</a>, <a href="#configure_zinc_scala-deps_used">deps_used</a>, <a href="#configure_zinc_scala-global_plugins">global_plugins</a>, <a href="#configure_zinc_scala-global_scalacopts">global_scalacopts</a>, <a href="#configure_zinc_scala-runtime_classpath">runtime_classpath</a>, <a href="#configure_zinc_scala-version">version</a>)
 </pre>
 
 
@@ -115,6 +124,15 @@ configure_zinc_scala(<a href="#configure_zinc_scala-name">name</a>, <a href="#co
         <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
         <p>
           Scalac plugins that will always be enabled.
+        </p>
+      </td>
+    </tr>
+    <tr id="configure_zinc_scala-global_scalacopts">
+      <td><code>global_scalacopts</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          Scalac options that will always be enabled.
         </p>
       </td>
     </tr>

--- a/rules/private/phases/phase_zinc_compile.bzl
+++ b/rules/private/phases/phase_zinc_compile.bzl
@@ -4,6 +4,7 @@ load(
 )
 load(
     "@rules_scala_annex//rules:providers.bzl",
+    _ScalaConfiguration = "ScalaConfiguration",
     _ZincConfiguration = "ZincConfiguration",
     _ZincInfo = "ZincInfo",
 )
@@ -19,6 +20,7 @@ load(
 #
 
 def phase_zinc_compile(ctx, g):
+    scala_configuration = ctx.attr.scala[_ScalaConfiguration]
     zinc_configuration = ctx.attr.scala[_ZincConfiguration]
 
     apis = ctx.actions.declare_file("{}/apis.gz".format(ctx.label.name))
@@ -45,6 +47,7 @@ def phase_zinc_compile(ctx, g):
     args.add("--compiler_bridge", zinc_configuration.compiler_bridge)
     args.add_all("--compiler_classpath", g.classpaths.compiler)
     args.add_all("--classpath", g.classpaths.compile)
+    args.add_all(scala_configuration.global_scalacopts, format_each = "--compiler_option=%s")
     args.add_all(ctx.attr.scalacopts, format_each = "--compiler_option=%s")
     args.add_all(javacopts, format_each = "--java_compiler_option=%s")
     args.add(ctx.label, format = "--label=%s")

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -11,6 +11,7 @@ ScalaConfiguration = provider(
         "compiler_classpath": "The compiler classpath.",
         "runtime_classpath": "The runtime classpath.",
         "global_plugins": "Globally enabled compiler plugins",
+        "global_scalacopts": "Globally enabled compiler options",
     },
 )
 
@@ -20,6 +21,7 @@ def _declare_scala_configuration_implementation(ctx):
         ScalaConfiguration(
             compiler_classpath = ctx.attr.compiler_classpath,
             global_plugins = ctx.attr.global_plugins,
+            global_scalacopts = ctx.attr.global_scalacopts,
             runtime_classpath = ctx.attr.runtime_classpath,
             version = ctx.attr.version,
         ),
@@ -39,6 +41,9 @@ declare_scala_configuration = rule(
         "global_plugins": attr.label_list(
             doc = "Scalac plugins that will always be enabled.",
             providers = [JavaInfo],
+        ),
+        "global_scalacopts": attr.string_list(
+            doc = "Scalac options that will always be enabled.",
         ),
     },
     doc = "Creates a `ScalaConfiguration`.",

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -479,6 +479,9 @@ configure_bootstrap_scala = rule(
             doc = "Scalac plugins that will always be enabled.",
             providers = [JavaInfo],
         ),
+        "global_scalacopts": attr.string_list(
+            doc = "Scalac options that will always be enabled.",
+        ),
     },
     implementation = _configure_bootstrap_scala_implementation,
 )
@@ -501,6 +504,9 @@ configure_zinc_scala = rule(
         "global_plugins": attr.label_list(
             doc = "Scalac plugins that will always be enabled.",
             providers = [JavaInfo],
+        ),
+        "global_scalacopts": attr.string_list(
+            doc = "Scalac options that will always be enabled.",
         ),
         "deps_direct": attr.string(default = "error"),
         "deps_used": attr.string(default = "error"),

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -18,6 +18,7 @@ def configure_bootstrap_scala_implementation(ctx):
         _ScalaConfiguration(
             compiler_classpath = ctx.attr.compiler_classpath,
             global_plugins = ctx.attr.global_plugins,
+            global_scalacopts = ctx.attr.global_scalacopts,
             runtime_classpath = ctx.attr.runtime_classpath,
             version = ctx.attr.version,
         ),
@@ -33,6 +34,7 @@ def configure_zinc_scala_implementation(ctx):
         _ScalaConfiguration(
             compiler_classpath = ctx.attr.compiler_classpath,
             global_plugins = ctx.attr.global_plugins,
+            global_scalacopts = ctx.attr.global_scalacopts,
             runtime_classpath = ctx.attr.runtime_classpath,
             version = ctx.attr.version,
         ),

--- a/rules/scala/private/repl.bzl
+++ b/rules/scala/private/repl.bzl
@@ -21,6 +21,7 @@ def scala_repl_implementation(ctx):
     args.add("--compiler_bridge", zinc_configuration.compiler_bridge.short_path)
     args.add_all("--compiler_classpath", scompiler_classpath.transitive_runtime_jars, map_each = _short_path)
     args.add_all("--classpath", classpath, map_each = _short_path)
+    args.add_all(scala_configuration.global_scalacopts, format_each = "--compiler_option=%s")
     args.add_all(ctx.attr.scalacopts, format_each = "--compiler_option=%s")
     args.set_param_file_format("multiline")
     args_file = ctx.actions.declare_file("{}/repl.params".format(ctx.label.name))

--- a/tests/scala/BUILD
+++ b/tests/scala/BUILD
@@ -142,3 +142,17 @@ configure_zinc_scala(
     version = "2.12.1",
     visibility = ["//visibility:public"],
 )
+
+# For global scalacoptions test
+configure_zinc_scala(
+    name = "zinc_2_12_6_fatal_deprecation_opt",
+    compiler_bridge = ":compiler_bridge_2_12_6",
+    compiler_classpath = compiler_classpath_2_12_6,
+    global_scalacopts = [
+        "-deprecation",
+        "-Xfatal-warnings",
+    ],
+    runtime_classpath = runtime_classpath_2_12_6,
+    version = "2.12.6",
+    visibility = ["//scalacopts/rule:__subpackages__"],
+)

--- a/tests/scalacopts/rule/BUILD
+++ b/tests/scalacopts/rule/BUILD
@@ -24,3 +24,9 @@ scala_library(
         "-deprecation",
     ],
 )
+
+scala_library(
+    name = "fatal_glob",
+    srcs = ["Deprecated.scala"],
+    scala = "//scala:zinc_2_12_6_fatal_deprecation_opt",
+)

--- a/tests/scalacopts/rule/test
+++ b/tests/scalacopts/rule/test
@@ -6,3 +6,5 @@ bazel build :default
 ! bazel build :fatal || false
 
 bazel build :warn
+
+! bazel build :fatal_glob || false


### PR DESCRIPTION
The `global_plugins` attribute allows Scala compiler plugins to be
globally configured, but provides no way to configure those plugins.
This adds a `global_scalacopts` attribute allowing configurations to be
passed to plugins that require it (among other things).