### PR TITLE
Include transitive_proto_paths in the call to protoc

### DIFF
--- a/rules/scala_proto/private/core.bzl
+++ b/rules/scala_proto/private/core.bzl
@@ -32,6 +32,11 @@ def scala_proto_library_implementation(ctx):
 
     args = ctx.actions.args()
     args.add("--output_dir", gendir.path)
+
+    for path in transitive_proto_path.to_list():
+        args.add("--proto_path=" + path)
+    if compiler.generator_params:
+        args.add("--generator_params", compiler.generator_params)
     args.add_all("--", transitive_sources)
     args.set_param_file_format("multiline")
     args.use_param_file("@%s", use_always = True)


### PR DESCRIPTION
Proto rules that specify `strip_import_prefix` or `import_prefix` may
have a different import path than their workspace-relative path, and so
may not be visible on compile. This includes the transitive proto paths
for a compile target to the ScalaPB compiler invocation ensuring that
such targets can be compiled.