### PR TITLE
Supports passing arguments to test framework

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
@@ -10,14 +10,14 @@ object SubprocessTestRunner {
   def main(args: Array[String]): Unit = {
     val input = new ObjectInputStream(System.in)
     val request = input.readObject().asInstanceOf[TestRequest]
-
+    val arguments = Seq.empty[String] //TODO
     val classLoader = ClassLoaders.sbtTestClassLoader(request.classpath.map(path => Paths.get(path).toUri.toURL))
 
     val loader = new TestFrameworkLoader(classLoader, request.logger)
     val framework = loader.load(request.framework).get
 
     val passed = ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader, arguments) { runner =>
         val tasks = runner.tasks(Array(TestHelper.taskDef(request.test, request.scopeAndTestName)))
         tasks.length == 0 || {
           val reporter = new TestReporter(request.logger)

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
@@ -24,12 +24,12 @@ class TestFrameworkLoader(loader: ClassLoader, logger: Logger) {
 }
 
 object TestHelper {
-  def withRunner[A](framework: Framework, scopeAndTestName: String, classLoader: ClassLoader)(
+  def withRunner[A](framework: Framework, scopeAndTestName: String, classLoader: ClassLoader, arguments: Seq[String])(
     f: Runner => A
   ) = {
     val options =
       if (framework.name == "specs2") Array("-ex", scopeAndTestName.replaceAll(".*::", "")) else Array.empty[String]
-    val runner = framework.runner(Array.empty, options, classLoader)
+    val runner = framework.runner(arguments.toArray, options, classLoader)
     try f(runner)
     finally runner.done()
   }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
@@ -17,10 +17,10 @@ import sbt.testing.{Event, Framework, Logger}
 import scala.collection.mutable
 
 class BasicTestRunner(framework: Framework, classLoader: ClassLoader, logger: Logger) extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val reporter = new TestReporter(logger)
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
@@ -43,13 +43,13 @@ class BasicTestRunner(framework: Framework, classLoader: ClassLoader, logger: Lo
 
 class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => ClassLoader, logger: Logger)
     extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
       }
@@ -60,7 +60,7 @@ class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => Cla
     tests.foreach { test =>
       val classLoader = classLoaderProvider()
       val isolatedFramework = new TestFrameworkLoader(classLoader, logger).load(framework.getClass.getName).get
-      TestHelper.withRunner(isolatedFramework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(isolatedFramework, scopeAndTestName, classLoader, arguments) { runner =>
         ClassLoaders.withContextClassLoader(classLoader) {
           val tasks = runner.tasks(Array(TestHelper.taskDef(test, scopeAndTestName)))
           tasks.foreach { task =>
@@ -90,12 +90,12 @@ class ProcessTestRunner(
   command: ProcessCommand,
   logger: Logger with Serializable
 ) extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
       }
@@ -130,5 +130,5 @@ class ProcessTestRunner(
 }
 
 trait TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String): Boolean
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]): Boolean
 }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -13,6 +13,7 @@ import java.net.URLClassLoader
 import java.nio.file.attribute.FileTime
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.time.Instant
+import java.util.ArrayList
 import java.util.Collections
 import java.util.regex.Pattern
 import java.util.zip.GZIPInputStream
@@ -45,6 +46,11 @@ object TestRunner {
       .help("Verbosity")
       .choices("HIGH", "MEDIUM", "LOW")
       .setDefault_("MEDIUM")
+    parser
+      .addArgument("--option")
+      .action(Arguments.append)
+      .help("Additional arguments for testing framework")
+      .setDefault_(new ArrayList[String]())
     parser
   }
 
@@ -171,7 +177,8 @@ object TestRunner {
             new ProcessTestRunner(framework, classpath, new ProcessCommand(executable.toString, arguments), logger)
           case "none" => new BasicTestRunner(framework, classLoader, logger)
         }
-        runner.execute(filteredTests, testScopeAndName.getOrElse(""))
+        val testFrameworkArguments = namespace.getList[String]("option").asScala.flatMap(_.split("\\s+"))
+        runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
       }
     }
     sys.exit(if (passed) 0 else 1)


### PR DESCRIPTION
For #222 

I thought I'd open this PR up so there would be a spot to get some feedback. I'm pretty new to bazel and Scala and am definitely willing to listen to feedback.

As it, it still needs to at least be documented and something in `SubprocessRunner`. If there is a spot some tests could be added, I'd also be happy to do that.


This adds a `--option` parameter to the TestRunner. `--option` can be given multiple times. Example below from me running tests using it in another project of mine.

`bazel test --test_arg=--option=-oDF --test_arg=--option='-l org.scalatest.tags.Slow' //websocket-api-server:tests`

One alternative approach would be to support this options in the file pointed to by the [java property](https://github.com/higherkindness/rules_scala/blob/1ac7073278b263305d8dbd66f889f6060fbde78e/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala#L107) `scalaAnnex.test.args`. That would let the flags persist across runs.

Another alternative, if persisting flags across runs is desired, would be to bubble these up to the `scala_test` rule (or I missing that you can already specify arguments here?).

I think some persistence would be nice so you can permanently and share between developers some common configuration (such as formatting flags).
