### PR TITLE
Allow test framework arguments to be specified

### DIFF
--- a/docs/scala.md
+++ b/docs/scala.md
@@ -72,7 +72,7 @@ $ bazel test --test_filter=my.test.Example :mytest
 $ bazel test --test_filter='my.test.*' :mytest
 
 # Pass arguments to underlying test framework
-$ bazel test --test_arg=--options='-oDF -l org.scalatest.tags.Slow' :mytest
+$ bazel test --test_arg=--framework_args='-oDF -l org.scalatest.tags.Slow' :mytest
 
 # Debug JVM on port 5005
 $ bazel test --test_arg=--debug=5005 :mytest

--- a/docs/scala.md
+++ b/docs/scala.md
@@ -59,7 +59,7 @@ e.g. ScalaTest, specs2, ScalaCheck, utest.
 
 * Additional options: ANSI color codes and verbosity
 
-* TODO: pass arguments to underlying test frameworks
+* Passing arguments to underlying test frameworks
 
 ```
 # Run tests
@@ -70,6 +70,9 @@ $ bazel test --test_filter=my.test.Example :mytest
 
 # Run all tests with Java/Scala package prefix (specs2)
 $ bazel test --test_filter='my.test.*' :mytest
+
+# Pass arguments to underlying test framework
+$ bazel test --test_arg=--options='-oDF -l org.scalatest.tags.Slow' :mytest
 
 # Debug JVM on port 5005
 $ bazel test --test_arg=--debug=5005 :mytest

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
@@ -10,14 +10,13 @@ object SubprocessTestRunner {
   def main(args: Array[String]): Unit = {
     val input = new ObjectInputStream(System.in)
     val request = input.readObject().asInstanceOf[TestRequest]
-    val testFrameworkArguments = Seq.empty[String]
     val classLoader = ClassLoaders.sbtTestClassLoader(request.classpath.map(path => Paths.get(path).toUri.toURL))
 
     val loader = new TestFrameworkLoader(classLoader, request.logger)
     val framework = loader.load(request.framework).get
 
     val passed = ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader, testFrameworkArguments) { runner =>
+      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader, request.testArgs) { runner =>
         val tasks = runner.tasks(Array(TestHelper.taskDef(request.test, request.scopeAndTestName)))
         tasks.length == 0 || {
           val reporter = new TestReporter(request.logger)

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
@@ -10,14 +10,14 @@ object SubprocessTestRunner {
   def main(args: Array[String]): Unit = {
     val input = new ObjectInputStream(System.in)
     val request = input.readObject().asInstanceOf[TestRequest]
-
+    val testFrameworkArguments = Seq.empty[String]
     val classLoader = ClassLoaders.sbtTestClassLoader(request.classpath.map(path => Paths.get(path).toUri.toURL))
 
     val loader = new TestFrameworkLoader(classLoader, request.logger)
     val framework = loader.load(request.framework).get
 
     val passed = ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, request.scopeAndTestName, classLoader, testFrameworkArguments) { runner =>
         val tasks = runner.tasks(Array(TestHelper.taskDef(request.test, request.scopeAndTestName)))
         tasks.length == 0 || {
           val reporter = new TestReporter(request.logger)

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
@@ -24,12 +24,12 @@ class TestFrameworkLoader(loader: ClassLoader, logger: Logger) {
 }
 
 object TestHelper {
-  def withRunner[A](framework: Framework, scopeAndTestName: String, classLoader: ClassLoader)(
+  def withRunner[A](framework: Framework, scopeAndTestName: String, classLoader: ClassLoader, arguments: Seq[String])(
     f: Runner => A
   ) = {
     val options =
       if (framework.name == "specs2") Array("-ex", scopeAndTestName.replaceAll(".*::", "")) else Array.empty[String]
-    val runner = framework.runner(Array.empty, options, classLoader)
+    val runner = framework.runner(arguments.toArray, options, classLoader)
     try f(runner)
     finally runner.done()
   }

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestRequest.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestRequest.scala
@@ -8,5 +8,6 @@ class TestRequest(
   val test: TestDefinition,
   val scopeAndTestName: String,
   val classpath: Seq[String],
-  val logger: Logger with Serializable
+  val logger: Logger with Serializable,
+  val testArgs: Seq[String]
 ) extends Serializable

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
@@ -17,10 +17,10 @@ import sbt.testing.{Event, Framework, Logger}
 import scala.collection.mutable
 
 class BasicTestRunner(framework: Framework, classLoader: ClassLoader, logger: Logger) extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val reporter = new TestReporter(logger)
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
@@ -43,13 +43,13 @@ class BasicTestRunner(framework: Framework, classLoader: ClassLoader, logger: Lo
 
 class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => ClassLoader, logger: Logger)
     extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
       }
@@ -60,7 +60,7 @@ class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => Cla
     tests.foreach { test =>
       val classLoader = classLoaderProvider()
       val isolatedFramework = new TestFrameworkLoader(classLoader, logger).load(framework.getClass.getName).get
-      TestHelper.withRunner(isolatedFramework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(isolatedFramework, scopeAndTestName, classLoader, arguments) { runner =>
         ClassLoaders.withContextClassLoader(classLoader) {
           val tasks = runner.tasks(Array(TestHelper.taskDef(test, scopeAndTestName)))
           tasks.foreach { task =>
@@ -90,12 +90,12 @@ class ProcessTestRunner(
   command: ProcessCommand,
   logger: Logger with Serializable
 ) extends TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String) = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]) = {
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
     ClassLoaders.withContextClassLoader(classLoader) {
-      TestHelper.withRunner(framework, scopeAndTestName, classLoader) { runner =>
+      TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
       }
@@ -130,5 +130,5 @@ class ProcessTestRunner(
 }
 
 trait TestFrameworkRunner {
-  def execute(tests: Seq[TestDefinition], scopeAndTestName: String): Boolean
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String, arguments: Seq[String]): Boolean
 }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
@@ -114,7 +114,8 @@ class ProcessTestRunner(
           test,
           scopeAndTestName,
           classpath.map(_.toString),
-          logger
+          logger,
+          arguments
         )
         val out = new ObjectOutputStream(process.getOutputStream)
         try out.writeObject(request)

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -46,6 +46,10 @@ object TestRunner {
       .choices("HIGH", "MEDIUM", "LOW")
       .setDefault_("MEDIUM")
     parser
+      .addArgument("--options")
+      .help("Additional arguments for testing framework")
+      .setDefault_("")
+    parser
   }
 
   private[this] val testArgParser = {
@@ -171,7 +175,8 @@ object TestRunner {
             new ProcessTestRunner(framework, classpath, new ProcessCommand(executable.toString, arguments), logger)
           case "none" => new BasicTestRunner(framework, classLoader, logger)
         }
-        runner.execute(filteredTests, testScopeAndName.getOrElse(""))
+        val testFrameworkArguments = namespace.getString("options").split("\\s+")
+        runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
       }
     }
     sys.exit(if (passed) 0 else 1)

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -46,7 +46,7 @@ object TestRunner {
       .choices("HIGH", "MEDIUM", "LOW")
       .setDefault_("MEDIUM")
     parser
-      .addArgument("--options")
+      .addArgument("--framework_args")
       .help("Additional arguments for testing framework")
     parser
   }
@@ -175,7 +175,7 @@ object TestRunner {
           case "none" => new BasicTestRunner(framework, classLoader, logger)
         }
         val testFrameworkArguments =
-          Option(namespace.getString("options")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
+          Option(namespace.getString("framework_args")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
         runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
       }
     }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -48,7 +48,6 @@ object TestRunner {
     parser
       .addArgument("--options")
       .help("Additional arguments for testing framework")
-      .setDefault_("")
     parser
   }
 
@@ -175,7 +174,7 @@ object TestRunner {
             new ProcessTestRunner(framework, classpath, new ProcessCommand(executable.toString, arguments), logger)
           case "none" => new BasicTestRunner(framework, classLoader, logger)
         }
-        val testFrameworkArguments = namespace.getString("options").split("\\s+")
+        val testFrameworkArguments = Option(namespace.getString("options")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
         runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
       }
     }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -174,7 +174,8 @@ object TestRunner {
             new ProcessTestRunner(framework, classpath, new ProcessCommand(executable.toString, arguments), logger)
           case "none" => new BasicTestRunner(framework, classLoader, logger)
         }
-        val testFrameworkArguments = Option(namespace.getString("options")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
+        val testFrameworkArguments =
+          Option(namespace.getString("options")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
         runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
       }
     }

--- a/tests/test-frameworks/isolation/test
+++ b/tests/test-frameworks/isolation/test
@@ -13,3 +13,7 @@ bazel build :classloader-shared
 ! bazel test :classloader-shared
 
 bazel test :process :process-2_11 :process-jvm
+
+bazel test --test_arg=--framework_args=-showtimes :none | grep 'be 2.*ms'
+bazel test --test_arg=--framework_args=-showtimes :classloader | grep 'be 2.*ms'
+bazel test --test_arg=--framework_args=-showtimes :process | grep 'be 2.*ms'

--- a/tests/test-frameworks/isolation/test
+++ b/tests/test-frameworks/isolation/test
@@ -14,6 +14,8 @@ bazel build :classloader-shared
 
 bazel test :process :process-2_11 :process-jvm
 
+# verify framework args work for each level of isolation
+! (bazel test :none | grep 'be 2.*ms')
 bazel test --test_arg=--framework_args=-showtimes :none | grep 'be 2.*ms'
 bazel test --test_arg=--framework_args=-showtimes :classloader | grep 'be 2.*ms'
 bazel test --test_arg=--framework_args=-showtimes :process | grep 'be 2.*ms'


### PR DESCRIPTION
This commit lets you pass test framework arguments. You can do it either through the command line like `bazel test --test_arg=--options='-oDF -l org.scalatest.tags.Slow' :mytest` or through the `scala_test` rule.

Example: 

```
scala_test(
  name = "tests",
  srcs = glob(["src/test/**/*.scala"]),
  resources = glob(["src/test/resources/**/*"]),
  resource_strip_prefix = "src/test/resources",
  deps = test_deps + [":server"],
  visibility = ["//visibility:public"],
  args = ["--options='-oDF -l org.scalatest.tags.Slow'"]
)
```

This does not currently support the subprocess runner.

I think to support that runner, we'd want to want to expose the `TestRunner.argParser` to `SubprocessTestRunner` and then parse the arguments passed into `SubprocessTestRunner.main`. This could be done by extracting some shared code.

This is probably something that should be done or documented as a feature that is currently not supported.

It wasn't clear to me where I would add tests for this. If there is a spot, please let me know and I'll gladly figure out some tests to add.

This PR is for issue #222