### PR TITLE
Print all errors

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -67,6 +67,7 @@ object ZincRunner extends WorkerMain[Namespace] {
     val parser = ArgumentParsers.newFor("zinc-worker").addHelp(true).build
     parser.addArgument("--persistence_dir", /* deprecated */ "--persistenceDir").metavar("path")
     parser.addArgument("--use_persistence").`type`(Arg.booleanType)
+    // deprecated
     parser.addArgument("--max_errors")
     parser.parseArgsOrFail(args.getOrElse(Array.empty))
   }
@@ -213,12 +214,8 @@ object ZincRunner extends WorkerMain[Namespace] {
     }
 
     val setup = {
-      val maxErrors: Int = worker.getString("max_errors") match {
-        case x: String if x.forall(_.isDigit) => x.toInt
-        case _                                => 10
-      }
       val incOptions = IncOptions.create()
-      val reporter = new LoggedReporter(maxErrors, logger)
+      val reporter = new LoggedReporter(logger)
       val skip = false
       Setup.create(lookup, skip, null, compilerCache, incOptions, reporter, Optional.empty(), Array.empty)
     }

--- a/tests/compile/logger/Example.scala
+++ b/tests/compile/logger/Example.scala
@@ -10,7 +10,7 @@ import xsbti.Severity
 object Example {
     def main(args: Array[String]) {
         val logger = new AnnexLogger(LogLevel.Info)
-        val reporter = new LoggedReporter(10, logger)
+        val reporter = new LoggedReporter(logger)
         val problem1 = problem("", new JavaPosition("Test Line", 100, "", 100), "Info Message 1", Severity.Info)
         val problem2 = problem("", new JavaPosition("Test Line", 200, "", 200), "Warning Message 2", Severity.Warn)
         val problem3 = problem("", new JavaPosition("Test Line", 300, "", 300), "Error Message 3", Severity.Error)


### PR DESCRIPTION
Limiting error count is of dubious value in Bazel, where there are many compiler
invocations anyway.