### PR TITLE
Catch errors from test framework

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -176,7 +176,12 @@ object TestRunner {
         }
         val testFrameworkArguments =
           Option(namespace.getString("framework_args")).map(_.split("\\s+").toList).getOrElse(Seq.empty[String])
-        runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
+        try runner.execute(filteredTests, testScopeAndName.getOrElse(""), testFrameworkArguments)
+        catch {
+          case e: Throwable =>
+            e.printStackTrace()
+            false
+        }
       }
     }
     sys.exit(if (passed) 0 else 1)


### PR DESCRIPTION
Exception during test initialization + some non-daemon thread created during this process prevents runner process from termination.