### PR TITLE
fix incorrect flag in docs

### DIFF
--- a/docs/stateful.md
+++ b/docs/stateful.md
@@ -11,5 +11,5 @@ is higher, because the sharing is (intentionally) aggressive.
 To enable Zinc's stateful compilation, add
 
 ```
---worker_extra_flag=ScalaCompile=--persistent_dir=.bazel-zinc
+--worker_extra_flag=ScalaCompile=--persistence_dir=.bazel-zinc
 ```


### PR DESCRIPTION
When trying to use the flag `--persistent_dir`, compilation fails, and the error below is thrown. Elsewhere in the docs I found the correct flag.

```Exception in thread "main" higherkindness.rules_scala.common.worker.WorkerMain$ExitTrapped
	at higherkindness.rules_scala.common.worker.WorkerMain$$anon$1.checkPermission(WorkerMain.scala:33)
	at java.base/java.lang.SecurityManager.checkExit(SecurityManager.java:534)
	at java.base/java.lang.Runtime.exit(Runtime.java:113)
	at java.base/java.lang.System.exit(System.java:1746)
	at net.sourceforge.argparse4j.internal.ArgumentParserImpl.parseArgsOrFail(ArgumentParserImpl.java:533)
	at higherkindness.rules_scala.workers.zinc.compile.ZincRunner$.init(ZincRunner.scala:72)
	at higherkindness.rules_scala.workers.zinc.compile.ZincRunner$.init(ZincRunner.scala:55)
	at higherkindness.rules_scala.common.worker.WorkerMain.main(WorkerMain.scala:73)
	at higherkindness.rules_scala.common.worker.WorkerMain.main$(WorkerMain.scala:22)
	at higherkindness.rules_scala.workers.zinc.compile.ZincRunner$.main(ZincRunner.scala:55)
	at higherkindness.rules_scala.workers.zinc.compile.ZincRunner.main(ZincRunner.scala)
```