### PR TITLE
remove stray print statement

### DIFF
--- a/rules/rules_scala.bzl
+++ b/rules/rules_scala.bzl
@@ -4,7 +4,6 @@ load(
 )
 
 def _emulate_rules_scala_repository_impl(repository_ctx):
-    print(repository_ctx.path(""))
     repository_ctx.file("WORKSPACE", content = "workspace(name = \"io_bazel_rules_scala\")")
     repository_ctx.file(
         "scala/scala.bzl",


### PR DESCRIPTION
I noticed a DEBUG statement showing up whenever using `emulate_rules_scala`. Maybe there's a purpose for it, but it seems like it was accidentally left in the code.