### PR TITLE
Faster incremental compilation options

### DIFF
--- a/docs/stateful.md
+++ b/docs/stateful.md
@@ -13,3 +13,8 @@ To enable Zinc's stateful compilation, add
 ```
 --worker_extra_flag=ScalaCompile=--persistence_dir=.bazel-zinc
 ```
+
+Additionally, intermediate inputs to compilation can be cached, for a significant performance benefit in some cases, by  
+```
+--worker_extra_flag=ScalaCompile=--persistence_dir=.bazel-zinc-outputs
+```

--- a/docs/stateful.md
+++ b/docs/stateful.md
@@ -14,7 +14,7 @@ To enable Zinc's stateful compilation, add
 --worker_extra_flag=ScalaCompile=--persistence_dir=.bazel-zinc
 ```
 
-Additionally, intermediate inputs to compilation can be cached, for a significant performance benefit in some cases, by  
+Additionally, intermediate inputs to compilation can be cached, for a significant performance benefit in some cases, by
 ```
---worker_extra_flag=ScalaCompile=--persistence_dir=.bazel-zinc-outputs
+--worker_extra_flag=ScalaCompile=--extracted_file_cache=.bazel-zinc-outputs
 ```

--- a/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
@@ -59,21 +59,23 @@ object FileUtil {
     }
   }
 
-  private def lock[A](lockFile: Path)(f: => A):A = {
+  private def lock[A](lockFile: Path)(f: => A): A = {
     Files.createDirectories(lockFile.getParent)
-    try Files.createFile(lockFile) catch { case _: FileAlreadyExistsException => }
+    try Files.createFile(lockFile)
+    catch { case _: FileAlreadyExistsException => }
     val channel = FileChannel.open(lockFile, StandardOpenOption.WRITE)
     try {
       val lock = channel.lock()
-      try f finally lock.release()
+      try f
+      finally lock.release()
     } finally channel.close()
   }
 
-  def extractZipIdempotently(archive: Path, output: Path): Unit = lock(output.getParent.resolve(s".${output.getFileName}.lock")) {
-    if (Files.exists(output)) ()
-    else extractZip(archive, output)
-  }
-
+  def extractZipIdempotently(archive: Path, output: Path): Unit =
+    lock(output.getParent.resolve(s".${output.getFileName}.lock")) {
+      if (Files.exists(output)) ()
+      else extractZip(archive, output)
+    }
 
   def extractZip(archive: Path, output: Path) = {
     val fileStream = Files.newInputStream(archive)

--- a/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
@@ -2,15 +2,11 @@ package higherkindness.rules_scala
 package workers.common
 
 import scala.annotation.tailrec
-
 import java.io.IOException
-import java.nio.file.FileAlreadyExistsException
-import java.nio.file.FileVisitResult
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.SimpleFileVisitor
-import java.nio.file.StandardCopyOption
+import java.nio.channels.FileChannel
+import java.nio.file.{FileAlreadyExistsException, FileVisitResult, Files, OpenOption, Path, SimpleFileVisitor, StandardCopyOption, StandardOpenOption}
 import java.nio.file.attribute.BasicFileAttributes
+import java.security.SecureRandom
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 
 class CopyFileVisitor(source: Path, target: Path) extends SimpleFileVisitor[Path] {
@@ -49,6 +45,7 @@ class ZipFileVisitor(root: Path, zip: ZipOutputStream) extends SimpleFileVisitor
 }
 
 object FileUtil {
+
   def copy(source: Path, target: Path) = Files.walkFileTree(source, new CopyFileVisitor(source, target))
 
   def delete(path: Path) = Files.walkFileTree(path, new DeleteFileVisitor)
@@ -61,6 +58,22 @@ object FileUtil {
       zip.close()
     }
   }
+
+  private def lock[A](lockFile: Path)(f: => A):A = {
+    Files.createDirectories(lockFile.getParent)
+    try Files.createFile(lockFile) catch { case _: FileAlreadyExistsException => }
+    val channel = FileChannel.open(lockFile, StandardOpenOption.WRITE)
+    try {
+      val lock = channel.lock()
+      try f finally lock.release()
+    } finally channel.close()
+  }
+
+  def extractZipIdempotently(archive: Path, output: Path): Unit = lock(output.getParent.resolve(s".${output.getFileName}.lock")) {
+    if (Files.exists(output)) ()
+    else extractZip(archive, output)
+  }
+
 
   def extractZip(archive: Path, output: Path) = {
     val fileStream = Files.newInputStream(archive)

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/Deps.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/Deps.scala
@@ -25,7 +25,7 @@ case class ExternalDep(file: Path, classpath: Path, analysis: DepAnalysisFiles) 
 
 object Dep {
 
-  def sha256(file: Path):String = {
+  def sha256(file: Path): String = {
     val digest = MessageDigest.getInstance("SHA-256")
     new BigInteger(1, digest.digest(Files.readAllBytes(file))).toString(16)
   }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/Deps.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/Deps.scala
@@ -2,12 +2,12 @@ package higherkindness.rules_scala
 package workers.zinc.compile
 
 import workers.common.FileUtil
+import java.math.BigInteger
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
 
-import java.io.File
-import java.nio.file.{Files, Path, StandardCopyOption}
-import java.util.zip.ZipInputStream
 import sbt.internal.inc.Relations
-import scala.annotation.tailrec
+
 import xsbti.compile.PerClasspathEntryLookup
 
 sealed trait Dep {
@@ -24,14 +24,29 @@ case class DepAnalysisFiles(apis: Path, relations: Path)
 case class ExternalDep(file: Path, classpath: Path, analysis: DepAnalysisFiles) extends Dep
 
 object Dep {
-  def create(classpath: Seq[Path], analyses: Map[Path, (Path, DepAnalysisFiles)]): Seq[Dep] = {
+
+  def sha256(file: Path):String = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    new BigInteger(1, digest.digest(Files.readAllBytes(file))).toString(16)
+  }
+
+  def create(depsCache: Option[Path], classpath: Seq[Path], analyses: Map[Path, (Path, DepAnalysisFiles)]): Seq[Dep] = {
     val roots = scala.collection.mutable.Set[Path]()
     classpath.flatMap { original =>
       analyses.get(original).fold[Option[Dep]](Some(LibraryDep(original))) { analysis =>
         val root = analysis._1
         if (roots.add(root)) {
-          FileUtil.extractZip(original, root)
-          Some(ExternalDep(original, root, analysis._2))
+          depsCache match {
+            case Some(cacheRoot) => {
+              val cachedPath = cacheRoot.resolve(sha256(original))
+              FileUtil.extractZipIdempotently(original, cachedPath)
+              Some(ExternalDep(original, cachedPath, analysis._2))
+            }
+            case _ => {
+              FileUtil.extractZip(original, root)
+              Some(ExternalDep(original, root, analysis._2))
+            }
+          }
         } else {
           None
         }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -75,7 +75,7 @@ object ZincRunner extends WorkerMain[Namespace] {
     parser.parseArgsOrFail(args.getOrElse(Array.empty))
   }
 
-  private def pathFrom(args: Namespace, name: String):Option[Path] = Option(args.getString(name)).map { dir =>
+  private def pathFrom(args: Namespace, name: String): Option[Path] = Option(args.getString(name)).map { dir =>
     Paths.get(dir.replace("~", sys.props.getOrElse("user.home", "")))
   }
 
@@ -121,7 +121,8 @@ object ZincRunner extends WorkerMain[Namespace] {
       val analyses = Option(
         namespace
           .getList[JList[String]]("analysis")
-      ).filter(_ => usePersistence).fold[Seq[JList[String]]](Nil)(_.asScala)
+      ).filter(_ => usePersistence)
+        .fold[Seq[JList[String]]](Nil)(_.asScala)
         .flatMap { value =>
           val prefixedLabel +: apis +: relations +: jars = value.asScala.toList
           val label = prefixedLabel.stripPrefix("_")
@@ -136,8 +137,6 @@ object ZincRunner extends WorkerMain[Namespace] {
       val originalClasspath = namespace.getList[File]("classpath").asScala.map(_.toPath)
       Dep.create(depsCache, originalClasspath, analyses)
     }
-
-
 
     // load persisted files
     val analysisFiles = AnalysisFiles(


### PR DESCRIPTION
# Summary
Profiling showed that the majority of time spent–for both small modules with many local Scala dependencies, and incremental compilation–was on unpacking zipfiles and later deleting them.
For incremental compilation, I added a flag `--extracted_file_cache` that can hold these unpacked files between runs. It's content-addressed by jar file content, so there's little chance of conflict.

For non-incremental compilation, I stopped extracting these files and simply treated them as external libraries; this removed the slowdown completely.

# Motivation
Our performance problems when incrementally recompiling a file in a "leaf" project, with lots of large local dependencies, were pretty bad. I profiled it and found that the overwhelming majority of time was spent unpacking classfiles from local deps and then deleting them: https://gist.github.com/stephenjudkins/0700dd627d7ec2f807fc3a9dc94a1880

This work was performed regardless if incremental compilation was enabled. On CI, when it is not, we can simply not unpack the files and treat them as library deps; locally, when incremental compilation is used, we can unpack them to a "cache" directory and reuse the unpacked files.

# Open questions
Why are the dependencies unpacked in the first place? Why can't Zinc use jars directly? This deserves further investigation, but I don't fully understand at the moment.

# Further work
https://github.com/sbt/zinc/pull/712 could allow the plugin to avoid unpacking files entirely