### PR TITLE
using target jdk (not host) for scala binaries

### DIFF
--- a/rules/common/private/utils.bzl
+++ b/rules/common/private/utils.bzl
@@ -60,11 +60,12 @@ def write_launcher(
     template = ctx.file._java_stub_template
     runfiles_enabled = False
 
-    java_path = str(ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
+    java_executable = ctx.attr._target_jdk[java_common.JavaRuntimeInfo].java_executable_runfiles_path
+    java_path = str(java_executable)
     if paths.is_absolute(java_path):
         javabin = java_path
     else:
-        javabin = "$JAVA_RUNFILES/{}/{}".format(ctx.workspace_name, ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
+        javabin = "$JAVA_RUNFILES/{}/{}".format(ctx.workspace_name, java_executable)
 
     base_substitutions = {
         "%classpath%": classpath,

--- a/rules/private/phases/phase_binary_launcher.bzl
+++ b/rules/private/phases/phase_binary_launcher.bzl
@@ -35,7 +35,7 @@ def phase_binary_launcher(ctx, g):
             files = inputs + files,
             transitive_files = depset(
                 order = "default",
-                transitive = [ctx.attr._jdk[java_common.JavaRuntimeInfo].files, g.javainfo.java_info.transitive_runtime_deps],
+                transitive = [ctx.attr._target_jdk[java_common.JavaRuntimeInfo].files, g.javainfo.java_info.transitive_runtime_deps],
             ),
             collect_default = True,
         ),

--- a/rules/private/phases/phase_test_launcher.bzl
+++ b/rules/private/phases/phase_test_launcher.bzl
@@ -16,7 +16,7 @@ load(
 #
 
 def phase_test_launcher(ctx, g):
-    files = ctx.attr._jdk[java_common.JavaRuntimeInfo].files.to_list() + [g.compile.zinc_info.apis]
+    files = ctx.attr._target_jdk[java_common.JavaRuntimeInfo].files.to_list() + [g.compile.zinc_info.apis]
 
     coverage_replacements = {}
     coverage_runner_jars = depset(direct = [])

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -170,10 +170,9 @@ _runtime_attributes = {
 }
 
 _runtime_private_attributes = {
-    "_jdk": attr.label(
+    "_target_jdk": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
         providers = [java_common.JavaRuntimeInfo],
-        cfg = "host",
     ),
     "_java_stub_template": attr.label(
         default = Label("@anx_java_stub_template//file"),

--- a/rules/scala/private/repl.bzl
+++ b/rules/scala/private/repl.bzl
@@ -51,7 +51,7 @@ def scala_repl_implementation(ctx):
             runfiles = ctx.runfiles(
                 collect_default = True,
                 collect_data = True,
-                files = ctx.attr._jdk[java_common.JavaRuntimeInfo].files.to_list(),
+                files = ctx.attr._target_jdk[java_common.JavaRuntimeInfo].files.to_list(),
                 transitive_files = files,
             ),
         ),


### PR DESCRIPTION
my use case:
when using remote execution I pass `--cpu=darwin --host-cpu=k8 --javabase=<macos jdk> --host_javabase=<linux jdk>`
and expect what produced binary will depend on macOS JDK