### PR TITLE
Allow users to consume abstract dependency coords themselves, pinning/resolving artifacts locally as they see fit

### DIFF
--- a/rules/scala/workspace.bzl
+++ b/rules/scala/workspace.bzl
@@ -9,31 +9,34 @@ filegroup(
     visibility = ["//visibility:public"]
 )"""
 
+def scala_artifacts():
+    return [
+        "org.scala-sbt:compiler-interface:1.2.1",
+        "org.scala-sbt:util-interface:1.2.1",
+        "org.scala-lang:scala-compiler:2.12.8",
+        "org.scala-lang:scala-library:2.12.8",
+        "org.scala-lang:scala-reflect:2.12.8",
+        "net.sourceforge.argparse4j:argparse4j:0.8.1",
+        "org.jacoco:org.jacoco.core:0.7.5.201505241946",
+        "com.lihaoyi:sourcecode_2.12:0.1.4,",
+        "org.scala-sbt:zinc_2.12:1.2.1",
+        "org.scala-sbt:test-interface:1.0",
+        "org.scala-sbt:util-interface:1.2.0",
+        "org.scala-sbt:zinc-compile-core_2.12:1.2.1",
+        "org.scala-sbt:zinc-persist_2.12:1.2.1",
+        "org.scala-sbt:zinc-core_2.12:1.2.1",
+        "org.scala-sbt:zinc-apiinfo_2.12:1.2.1",
+        "org.scala-sbt:zinc-classpath_2.12:1.2.1",
+        "org.scala-sbt:compiler-interface:1.2.1",
+        "ch.epfl.scala:bloop-frontend_2.12:1.0.0",
+        "com.thesamet.scalapb:scalapb-runtime_2.12:0.9.0",
+        "org.scala-sbt:util-logging_2.12:1.2.0",
+    ]
+
 def scala_repositories(java_launcher_version = "0.29.1"):
     maven_install(
         name = "annex",
-        artifacts = [
-            "org.scala-sbt:compiler-interface:1.2.1",
-            "org.scala-sbt:util-interface:1.2.1",
-            "org.scala-lang:scala-compiler:2.12.8",
-            "org.scala-lang:scala-library:2.12.8",
-            "org.scala-lang:scala-reflect:2.12.8",
-            "net.sourceforge.argparse4j:argparse4j:0.8.1",
-            "org.jacoco:org.jacoco.core:0.7.5.201505241946",
-            "com.lihaoyi:sourcecode_2.12:0.1.4,",
-            "org.scala-sbt:zinc_2.12:1.2.1",
-            "org.scala-sbt:test-interface:1.0",
-            "org.scala-sbt:util-interface:1.2.0",
-            "org.scala-sbt:zinc-compile-core_2.12:1.2.1",
-            "org.scala-sbt:zinc-persist_2.12:1.2.1",
-            "org.scala-sbt:zinc-core_2.12:1.2.1",
-            "org.scala-sbt:zinc-apiinfo_2.12:1.2.1",
-            "org.scala-sbt:zinc-classpath_2.12:1.2.1",
-            "org.scala-sbt:compiler-interface:1.2.1",
-            "ch.epfl.scala:bloop-frontend_2.12:1.0.0",
-            "com.thesamet.scalapb:scalapb-runtime_2.12:0.9.0",
-            "org.scala-sbt:util-logging_2.12:1.2.0",
-        ],
+        artifacts = scala_artifacts(),
         repositories = [
             "https://repo.maven.apache.org/maven2",
         ],

--- a/rules/scala_proto/workspace.bzl
+++ b/rules/scala_proto/workspace.bzl
@@ -3,14 +3,17 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 def scala_proto_register_toolchains():
     native.register_toolchains("@rules_scala_annex//rules/scala_proto:scalapb_scala_proto_toolchain")
 
+def scala_proto_artifacts():
+    return [
+        "com.github.os72:protoc-jar:3.8.0",
+        "com.thesamet.scalapb:compilerplugin_2.12:0.9.0",
+        "com.thesamet.scalapb:protoc-bridge_2.12:0.7.8",
+    ]
+
 def scala_proto_repositories():
     maven_install(
         name = "annex_proto",
-        artifacts = [
-            "com.github.os72:protoc-jar:3.8.0",
-            "com.thesamet.scalapb:compilerplugin_2.12:0.9.0",
-            "com.thesamet.scalapb:protoc-bridge_2.12:0.7.8",
-        ],
+        artifacts = scala_proto_artifacts(),
         repositories = [
             "https://repo.maven.apache.org/maven2",
         ],

--- a/rules/scalafmt/workspace.bzl
+++ b/rules/scalafmt/workspace.bzl
@@ -1,13 +1,16 @@
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+def scalafmt_artifacts():
+    return [
+        "org.scalameta:parsers_2.12:4.2.0",
+        "com.geirsson:metaconfig-core_2.12:0.8.3",
+        "org.scalameta:scalafmt-core_2.12:jar:2.0.0",
+    ]
+
 def scalafmt_repositories():
     maven_install(
         name = "annex_scalafmt",
-        artifacts = [
-            "org.scalameta:parsers_2.12:4.2.0",
-            "com.geirsson:metaconfig-core_2.12:0.8.3",
-            "org.scalameta:scalafmt-core_2.12:jar:2.0.0",
-        ],
+        artifacts = scalafmt_artifacts(),
         repositories = [
             "https://repo.maven.apache.org/maven2",
         ],

--- a/tests/workspace.bzl
+++ b/tests/workspace.bzl
@@ -1,25 +1,28 @@
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+def test_artifacts():
+    return [
+        "org.scala-sbt:compiler-interface:1.2.1",
+        "org.scala-lang.modules:scala-xml_2.12:1.0.6",
+        "org.scalacheck:scalacheck_2.12:1.13.4",
+        "org.scalacheck:scalacheck_2.11:1.13.4",
+        "org.specs2:specs2-matcher_2.12:4.0.3",
+        "org.specs2:specs2-common_2.12:4.0.3",
+        "org.specs2:specs2-core_2.12:4.0.3",
+        "org.specs2:specs2-matcher_2.11:3.9.5",
+        "org.specs2:specs2-common_2.11:3.9.5",
+        "org.specs2:specs2-core_2.11:3.9.5",
+        "com.thesamet.scalapb:scalapb-runtime_2.12:0.9.0",
+        "com.thesamet.scalapb:lenses_2.12:0.9.0",
+        "com.google.protobuf:protobuf-java:3.9.0",
+        "org.scalatest:scalatest_2.12:3.0.4",
+        "org.scalactic:scalactic_2.12:3.0.4",
+    ]
+
 def test_dependencies():
     maven_install(
         name = "annex_test",
-        artifacts = [
-            "org.scala-sbt:compiler-interface:1.2.1",
-            "org.scala-lang.modules:scala-xml_2.12:1.0.6",
-            "org.scalacheck:scalacheck_2.12:1.13.4",
-            "org.scalacheck:scalacheck_2.11:1.13.4",
-            "org.specs2:specs2-matcher_2.12:4.0.3",
-            "org.specs2:specs2-common_2.12:4.0.3",
-            "org.specs2:specs2-core_2.12:4.0.3",
-            "org.specs2:specs2-matcher_2.11:3.9.5",
-            "org.specs2:specs2-common_2.11:3.9.5",
-            "org.specs2:specs2-core_2.11:3.9.5",
-            "com.thesamet.scalapb:scalapb-runtime_2.12:0.9.0",
-            "com.thesamet.scalapb:lenses_2.12:0.9.0",
-            "com.google.protobuf:protobuf-java:3.9.0",
-            "org.scalatest:scalatest_2.12:3.0.4",
-            "org.scalactic:scalactic_2.12:3.0.4",
-        ],
+        artifacts = test_artifacts(),
         repositories = [
             "https://repo.maven.apache.org/maven2",
         ],


### PR DESCRIPTION
It's our policy to use our own, private maven server to store/serve dependencies. Previously, this repo had included pinned dependencies on public maven repos. This is the minimal change necessary to handle this ourselves without copy/pasting the full list of artifacts into our repo; currently we do it by calling `maven_install` ourselves with the `scala_artifacts` and `scala_proto_artifacts` we imported from these files. Additionally, we had to add our own `@anx_java_stub_template`file.