### PR TITLE
Respect scalafmt fatalWarnings config

### DIFF
--- a/rules/scalafmt/scalafmt/ScalafmtRunner.scala
+++ b/rules/scalafmt/scalafmt/ScalafmtRunner.scala
@@ -39,9 +39,14 @@ object ScalafmtRunner extends WorkerMain[Unit] {
         format(source)
       } catch {
         case e @ (_: org.scalafmt.Error | _: scala.meta.parsers.ParseException) => {
-          System.err.println(Color.Warning("Unable to format file due to bug in scalafmt"))
-          System.err.println(Color.Warning(e.toString))
-          source
+          if (config.runner.fatalWarnings) {
+            System.err.println(Color.Error("Exception thrown by Scalafmt and fatalWarnings is enabled"))
+            throw e
+          } else {
+            System.err.println(Color.Warning("Unable to format file due to bug in scalafmt"))
+            System.err.println(Color.Warning(e.toString))
+            source
+          }
         }
       }
 


### PR DESCRIPTION
Before this change, exceptions thrown by the scalafmt would all be treated as warnings. This change updates the code to treat these exceptions as errors if the formatter is configured with `runner.fatalWarnings = true`.