### PR TITLE
NixOS fix

### DIFF
--- a/rules/private/phases/phase_zinc_compile.bzl
+++ b/rules/private/phases/phase_zinc_compile.bzl
@@ -89,6 +89,7 @@ def phase_zinc_compile(ctx, g):
         executable = worker.files_to_run.executable,
         input_manifests = input_manifests,
         execution_requirements = _resolve_execution_reqs(ctx, {"no-sandbox": "1", "supports-workers": "1"}),
+        use_default_shell_env = True,
         arguments = [args],
     )
 

--- a/rules/private/phases/phase_zinc_depscheck.bzl
+++ b/rules/private/phases/phase_zinc_depscheck.bzl
@@ -45,6 +45,7 @@ def phase_zinc_depscheck(ctx, g):
             executable = deps_configuration.worker.files_to_run.executable,
             input_manifests = worker_input_manifests,
             execution_requirements = _resolve_execution_reqs(ctx, {"supports-workers": "1"}),
+            use_default_shell_env = True,
             arguments = [deps_args],
         )
         deps_checks[name] = deps_check


### PR DESCRIPTION
This patch fixes strange behaviour on NixOS where `cat` command cannot be found (but available in shell by coreutils):

```
[nix-shell:~/Projects/testproj/server]$ make debug
bazel build --sandbox_debug --define=ABSOLUTE_JAVABASE=/nix/store/zzcjchd3a66lbjan23pjhq1bk0s8a7h4-jdk-14.28.21 --host_javabase=@bazel_tools//tools/jdk:absolute_javabase --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
	//modules/libtgvoip/scala:app
INFO: Analyzed target //modules/libtgvoip/scala:app (127 packages loaded, 1239 targets configured).
INFO: Found 1 target...
ERROR: /data/home/x/Projects/testproj/server/modules/libtgvoip/scala/BUILD.bazel:3:13: ScalaCompile modules/libtgvoip/scala/app/classes.jar failed: Worker process did not return a WorkResponse:

---8<---8<--- Start of log, file at /data/home/x/.cache/bazel/_bazel_x/96364899299eda1f2874771f867b1be1/bazel-workers/worker-15-ScalaCompile.log ---8<---8<---
/data/home/x/.cache/bazel/_bazel_x/96364899299eda1f2874771f867b1be1/execroot/xxx/bazel-out/host/bin/external/rules_scala_annex/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/compile-bin: line 250: cat: command not found
Unrecognized option: --persistent_worker
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
---8<---8<--- End of log ---8<---8<---
Target //modules/libtgvoip/scala:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.971s, Critical Path: 0.02s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
make: *** [Makefile:19: debug] Error 1
```

//cc @SrodriguezO